### PR TITLE
Vim script 用の正規表現には `\m` を前置するように修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ const pattern = await denops.dispatch("kensaku", "query", "kensaku");
 
 ```vim
 function! Search(value) abort
-  let @/ = '\m' .. a:value
+  let @/ = a:value
   normal! n
 endfunction
 
@@ -83,7 +83,7 @@ call Search(kensaku#query('kensaku'))
 
 ```vim
 function! Search(value) abort
-  let @/ = '\m' .. a:value
+  let @/ = a:value
   normal! n
 endfunction
 
@@ -92,15 +92,12 @@ call kensaku#query_async('kensaku', {
       \})
 ```
 
-## v2 との違い
+## 正規表現モードに関して (magic/very magic)
 
-Kensaku [v2](https://github.com/lambdalisue/kensaku.vim/tree/v2) までは
-`kensaku#query()` などで返す正規表現は JavaScript のものだったため `\v`
-を前置することで Very magic を指定する必要がありました。 Kensaku v3 からは
-`kensaku#query()` は Vim script の正規表現を返すように変更されたので `\v`
-の代わりに `\m` を前置します。 なおプラグイン作者などが利用する
-`denops.dispatch()` 経由での呼び出しは依然として JavaScript
-の正規表現を返します。
+`kensaku#query()` がデフォルトで返す正規表現には `\m` が含まれるようになったため
+`\v` や `\m` の前置が不要になりました。 なお、この挙動はデフォルトの `"rxop"`
+(`g:kensaku#rxop#vim`) で定義されているため、カスタムの `"rxop"`
+を指定した場合は別です。
 
 ## 参考情報
 

--- a/autoload/kensaku/rxop.vim
+++ b/autoload/kensaku/rxop.vim
@@ -1,2 +1,2 @@
-let g:kensaku#rxop#vim = ['\|', '\%(', '\)', '[', ']', '']
+let g:kensaku#rxop#vim = ['\m', '\|', '\%(', '\)', '[', ']', '']
 let g:kensaku#rxop#javascript = ['|', '(?:', ')', '[', ']', '']

--- a/denops/kensaku/migemo.ts
+++ b/denops/kensaku/migemo.ts
@@ -49,7 +49,9 @@ async function getMigemo(denops: Denops): Promise<jsmigemo.Migemo> {
   return migemo;
 }
 
-type Rxop = [string, string, string, string, string, string];
+type Rxop =
+  | [string, string, string, string, string, string]
+  | [string, string, string, string, string, string, string];
 
 type QueryOption = {
   rxop?: Rxop;
@@ -58,7 +60,9 @@ type QueryOption = {
 export function assertQueryOption(x: unknown): asserts x is QueryOption {
   if (
     !(u.isObject(x) &&
-      (x.rxop == null || u.isArray(x.rxop, u.isString) && x.rxop.length === 6))
+      (x.rxop == null ||
+        u.isArray(x.rxop, u.isString) &&
+          (x.rxop.length === 6 || x.rxop.length === 7)))
   ) {
     throw new Error("Not a QueryOption");
   }
@@ -72,8 +76,10 @@ export async function query(
   option: QueryOption = {},
 ): Promise<string> {
   const migemo = await getMigemo(denops);
+  const rxop = option.rxop || rxopJavaScript;
+  const prefix = rxop.length === 7 ? rxop.shift() : "";
   migemo.setRxop(option.rxop || rxopJavaScript);
-  return migemo.query(value);
+  return prefix + migemo.query(value);
 }
 
 export async function setRomanTable(

--- a/doc/kensaku.jax
+++ b/doc/kensaku.jax
@@ -77,7 +77,7 @@ kensaku#query({value}[, {option}])
 	{value} をローマ字として解釈し、検索するための正規表現を返します。
 >
 	function! Search(value) abort
-	  let @/ = '\m' .. a:value
+	  let @/ = a:value
 	  normal! n
 	endfunction
 
@@ -86,14 +86,18 @@ kensaku#query({value}[, {option}])
 	{option} には以下のパラメータがあります。
 
 	"rxop"	正規表現に利用する記号文字のリストです。
-		"[or, startGroup, endGroup, startClass, endClass, newline]" で
-		表され、それぞれ以下の意味を持ちます。
+		"[or, startGroup, endGroup, startClass, endClass, newline]" or
+		"[prefix, or, startGroup, endGroup, startClass, endClass,
+		newline]" で表され、それぞれ以下の意味を持ちます。
+
+		prefix		正規表現前に前置する文字列。未指定時は空文字。
 		or		選択子 (alternation operator)。|/bar|
 		startGroup	グループ化の開始。|/\(|
 		endGroup	グループ化の終了。|/\)|
 		startClass	文字クラスの開始。|/\[]|
 		endClass	文字クラスの終了。|/\[]|
 		newline		行末。|/\_s|
+
 		デフォルト: |g:kensaku#rxop#vim|
 >
 	" :grep で kensaku.vim を使う
@@ -124,7 +128,7 @@ kensaku#query_async({value}, {success}[, {option}])
 	"failure"	エラー時に呼ばれるコールバック関数です。
 >
 	function! Search(value) abort
-	  let @/ = '\m' .. a:value
+	  let @/ = a:value
 	  normal! n
 	endfunction
 

--- a/doc/kensaku.jax
+++ b/doc/kensaku.jax
@@ -65,10 +65,6 @@ VARIABLES					*kensaku-variables*
 	      \ 'rxop': g:kensaku#rxop#javascript,
 	      \})
 <
-*g:kensaku_disable_v3_migration_warning*
-	Kensaku v3 で適用された破壊的変更に関する警告メッセージを非表示にしま
-	す。なお、このメッセージ自体は v3.0.1 以降で削除される予定です。
-
 -----------------------------------------------------------------------------
 FUNCTIONS					*kensaku-functions*
 

--- a/plugin/kensaku.vim
+++ b/plugin/kensaku.vim
@@ -14,14 +14,3 @@ call s:define(
       \ 'kensaku_dictionary_cache',
       \ expand('~/.cache/kensaku.vim/migemo-compact-dict')
       \)
-
-" XXX
-" Remove this warning message after v3.0.0
-if !exists('g:kensaku_disable_v3_migration_warning')
-  echohl WarningMsg
-  echomsg '[kensaku] BREAKING CHANGES:'
-  echomsg '[kensaku] Kensaku v3 returns Vim script regex from `kensaku#query()` function so users need to prepend `\m` instead of `\m`.'
-  echomsg '[kensaku] Additionally, Optional arguments of `kensaku#query_async()` has slightly changed. See help for more detail.'
-  echomsg '[kensaku] Disable this message by `let g:kensaku_disable_v3_migration_warning = 1` or wait until the next release.'
-  echohl None
-endif


### PR DESCRIPTION
SSIA