### PR TITLE
エスケープ対象の指定

### DIFF
--- a/autoload/kensaku/rxop.vim
+++ b/autoload/kensaku/rxop.vim
@@ -1,2 +1,2 @@
-let g:kensaku#rxop#vim = ['\m', '\|', '\%(', '\)', '[', ']', '']
-let g:kensaku#rxop#javascript = ['|', '(?:', ')', '[', ']', '']
+let g:kensaku#rxop#vim = ['\m', '\|', '\%(', '\)', '[', ']', '', '\\.[]*^$']
+let g:kensaku#rxop#javascript = ['|', '(?:', ')', '[', ']', '', '\\.[]{}()*+-?^$|']

--- a/denops/kensaku/migemo.ts
+++ b/denops/kensaku/migemo.ts
@@ -4,7 +4,7 @@ import * as fs from "https://deno.land/std@0.172.0/fs/mod.ts";
 import * as u from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
 import * as batch from "https://deno.land/x/denops_std@v4.0.0/batch/mod.ts";
 import * as vars from "https://deno.land/x/denops_std@v4.0.0/variable/mod.ts";
-import * as jsmigemo from "https://cdn.jsdelivr.net/npm/jsmigemo@0.4.6/dist/jsmigemo.min.mjs";
+import * as jsmigemo from "https://cdn.jsdelivr.net/npm/jsmigemo@0.4.7/dist/jsmigemo.min.mjs";
 
 let migemo: jsmigemo.Migemo | undefined;
 
@@ -50,8 +50,8 @@ async function getMigemo(denops: Denops): Promise<jsmigemo.Migemo> {
 }
 
 type Rxop =
-  | [string, string, string, string, string, string]
-  | [string, string, string, string, string, string, string];
+  | [string, string, string, string, string, string, string]
+  | [string, string, string, string, string, string, string, string];
 
 type QueryOption = {
   rxop?: Rxop;
@@ -62,13 +62,13 @@ export function assertQueryOption(x: unknown): asserts x is QueryOption {
     !(u.isObject(x) &&
       (x.rxop == null ||
         u.isArray(x.rxop, u.isString) &&
-          (x.rxop.length === 6 || x.rxop.length === 7)))
+          (x.rxop.length === 7 || x.rxop.length === 8)))
   ) {
     throw new Error("Not a QueryOption");
   }
 }
 
-const rxopJavaScript = ["|", "(?:", ")", "[", "]", ""];
+const rxopJavaScript = ["|", "(?:", ")", "[", "]", "", "\\.[]{}()*+-?^$|"];
 
 export async function query(
   denops: Denops,
@@ -77,7 +77,7 @@ export async function query(
 ): Promise<string> {
   const migemo = await getMigemo(denops);
   const rxop = option.rxop || rxopJavaScript;
-  const prefix = rxop.length === 7 ? rxop.shift() : "";
+  const prefix = rxop.length === 8 ? rxop.shift() : "";
   migemo.setRxop(option.rxop || rxopJavaScript);
   return prefix + migemo.query(value);
 }

--- a/doc/kensaku.jax
+++ b/doc/kensaku.jax
@@ -82,9 +82,10 @@ kensaku#query({value}[, {option}])
 	{option} には以下のパラメータがあります。
 
 	"rxop"	正規表現に利用する記号文字のリストです。
-		"[or, startGroup, endGroup, startClass, endClass, newline]" or
-		"[prefix, or, startGroup, endGroup, startClass, endClass,
-		newline]" で表され、それぞれ以下の意味を持ちます。
+		"[or, startGroup, endGroup, startClass, endClass, newline,
+		escape]" or "[prefix, or, startGroup, endGroup, startClass,
+		endClass, newline, escape]" で表され、それぞれ以下の意味を持ち
+		ます。
 
 		prefix		正規表現前に前置する文字列。未指定時は空文字。
 		or		選択子 (alternation operator)。|/bar|
@@ -93,6 +94,8 @@ kensaku#query({value}[, {option}])
 		startClass	文字クラスの開始。|/\[]|
 		endClass	文字クラスの終了。|/\[]|
 		newline		行末。|/\_s|
+		escape		辞書に含まれる文字のうち、'\' でエスケープする
+				対象。
 
 		デフォルト: |g:kensaku#rxop#vim|
 >
@@ -107,7 +110,7 @@ kensaku#query({value}[, {option}])
 	  set grepprg=rg\ -e\ $*\ --vimgrep
 	  " :execute は '|' でコマンドを区切るのでエスケープ
 	  execute 'grep' string(kensaku#query(a:input, {
-	        \ 'rxop': ['\|', '(', ')', '[', ']', ''],
+	        \ 'rxop': ['\|', '(', ')', '[', ']', '', '\\.[]{}()*+-?^$|'],
 	        \}))
 	  let &grepprg = grepprg
 	endfunction


### PR DESCRIPTION
これまでは、辞書に含まれる文字列のうち `\.[]{}()*+-?^$|` が `\` でエスケープされるようになっていました。
これが jsmigemo v0.4.7 で setRxop() を通して設定可能になったので、それに対応するための PR です。
設定方法に破壊的変更が入りますが、プリセットも更新するため影響は少ないと思われます。
