### PR TITLE
fix: ~ should be escaped

### DIFF
--- a/autoload/kensaku/rxop.vim
+++ b/autoload/kensaku/rxop.vim
@@ -6,7 +6,7 @@ let g:kensaku#rxop#vim = #{
       \ startClass: '[',
       \ endClass: ']',
       \ newline: '',
-      \ escape: '\\.[]*^$',
+      \ escape: '\\.[]*~^$',
       \}
 let g:kensaku#rxop#javascript = #{
       \ or: '|',


### PR DESCRIPTION
as it has the special functionality

    :h /~
    ~	matches the last given substitute string	*/~* */\~*

Otherwise, following search fails with error

    /<c-r>=kensaku#query('a~')<cr><cr>

    E33: No previous substitute regular expression
    E383: Invalid search string: \m\%(a~\|あ〜\|ア〜\|ａ～\|ｱ〜\)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the escape character string in the Kensaku plugin configuration, enhancing the handling of regular expressions.
  
- **Bug Fixes**
	- Improved character treatment in regular expressions for better functionality within Vim.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->